### PR TITLE
WIP: Reduce size built base image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
 
 script:
   - docker build -t webviz/base_image .
+  - docker image ls
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 script:
   - docker build -t webviz/base_image .
   - docker image ls
-  - docker history webviz/base_image .
+  - docker history webviz/base_image
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 script:
   - docker build -t webviz/base_image .
   - docker image ls
+  - docker history webviz/base_image .
 
 deploy:
   provider: script

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,10 @@ RUN pip install --upgrade pip webviz-config webviz-subsurface --no-cache-dir \
 # Prepare for adding the webviz instance app #
 ##############################################
 
-ENV LISTEN_PORT=5000
+ENV LISTEN_PORT=5000 UWSGI_INI=/uwsgi.ini STATIC_URL=/dash_app/assets
+
 EXPOSE 5000
 
 COPY uwsgi.ini /
-
-ENV UWSGI_INI /uwsgi.ini
-ENV STATIC_URL /dash_app/assets
 
 WORKDIR /dash_app

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,13 @@ FROM tiangolo/uwsgi-nginx-flask:python3.7
 # Install the webviz ecosystem #
 ################################
 
-# 1) Install necessary Python packages.
-# 2) Change from full plotly bundle to one not depending on javascript eval.
-#    See https://github.com/plotly/dash-core-components/issues/462 for details.
+RUN pip install --no-cache-dir --upgrade pip webviz-config webviz-subsurface
 
-# When docker build squash argument is not experimental, the commands can
-# be split out without increasing image size.
+# Change from full plotly bundle to one not depending on javascript eval.
+# See https://github.com/plotly/dash-core-components/issues/462 for details.
 
-RUN pip install --upgrade pip webviz-config webviz-subsurface --no-cache-dir \
-    && DCC_DIR='/usr/local/lib/python3.7/site-packages/dash_core_components' \
-    && PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o '[0-9]+.[0-9]+.[0-9]+'` \
+ENV DCC_DIR='/usr/local/lib/python3.7/site-packages/dash_core_components'
+RUN PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o '[0-9]+.[0-9]+.[0-9]+'` \
     && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
     && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \
     && sed -i "s/plotly-$PLOTLY_VERSION.min.js/plotly-cartesian-$PLOTLY_VERSION.min.js/g" $DCC_DIR/__init__.py
@@ -22,10 +19,12 @@ RUN pip install --upgrade pip webviz-config webviz-subsurface --no-cache-dir \
 # Prepare for adding the webviz instance app #
 ##############################################
 
-ENV LISTEN_PORT=5000 UWSGI_INI=/uwsgi.ini STATIC_URL=/dash_app/assets
-
+ENV LISTEN_PORT=5000
 EXPOSE 5000
 
 COPY uwsgi.ini /
+
+ENV UWSGI_INI /uwsgi.ini
+ENV STATIC_URL /dash_app/assets
 
 WORKDIR /dash_app

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,8 @@ FROM tiangolo/uwsgi-nginx-flask:python3.7
 # When docker build squash argument is not experimental, the commands can
 # be split out without increasing image size.
 
-ENV DCC_DIR='/usr/local/lib/python3.7/site-packages/dash_core_components'
-
 RUN pip install --upgrade pip webviz-config webviz-subsurface --no-cache-dir \
+    && DCC_DIR='/usr/local/lib/python3.7/site-packages/dash_core_components' \
     && PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o '[0-9]+.[0-9]+.[0-9]+'` \
     && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
     && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,17 @@ FROM tiangolo/uwsgi-nginx-flask:python3.7
 # Install the webviz ecosystem #
 ################################
 
-RUN pip install -U pip
+# 1) Install necessary Python packages.
+# 2) Change from full plotly bundle to one not depending on javascript eval.
+#    See https://github.com/plotly/dash-core-components/issues/462 for details.
 
-RUN pip install webviz-config webviz-subsurface
-
-# Change from full plotly bundle to one not depending on javascript eval.
-# See https://github.com/plotly/dash-core-components/issues/462 for details.
+# When docker build squash argument is not experimental, the commands can
+# be split out without increasing image size.
 
 ENV DCC_DIR='/usr/local/lib/python3.7/site-packages/dash_core_components'
-RUN PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o '[0-9]+.[0-9]+.[0-9]+'` \
+
+RUN pip install --upgrade pip webviz-config webviz-subsurface --no-cache-dir \
+    && PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o '[0-9]+.[0-9]+.[0-9]+'` \
     && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
     && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \
     && sed -i "s/plotly-$PLOTLY_VERSION.min.js/plotly-cartesian-$PLOTLY_VERSION.min.js/g" $DCC_DIR/__init__.py


### PR DESCRIPTION
Reduced from 1.81 GB to 1.62 GB by
- Tell `pip` not to cache files.