### PR TITLE
Change base image and server stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
-Dockerfile
 .dockerignore
+.travis.yml
+deploy_docker_image.sh
+Dockerfile
+LICENSE
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
          flask \
          webviz-config \
          webviz-subsurface \ 
-    && PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o "[0-9]+.[0-9]+.[0-9]+"` \
+    && PLOTLY_VERSION=$(find $DCC_DIR -maxdepth 1 -name 'plotly-*.min.js' | grep -oE "[0-9]+.[0-9]+.[0-9]+") \
     && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
     && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \
     && sed -i "s/plotly-$PLOTLY_VERSION.min.js/plotly-cartesian-$PLOTLY_VERSION.min.js/g" $DCC_DIR/__init__.py \
@@ -33,6 +33,7 @@ RUN apt-get update \
          libc6-dev \
     && apt-get autoremove -y \
     && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && useradd --create-home appuser
 
 WORKDIR /home/appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ EXPOSE 5000
 
 ENV DCC_DIR="/usr/local/lib/python3.7/site-packages/dash_core_components"
 
-COPY . .
-
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
          wget \
@@ -34,8 +32,14 @@ RUN apt-get update \
          libc-dev-bin \
          libc6-dev \
     && apt-get autoremove -y \
-    && apt-get clean
+    && apt-get clean \
+    && useradd --create-home appuser
+
+WORKDIR /home/appuser
+USER appuser
+
+COPY --chown=appuser . .
 
 CMD gunicorn \
-      --config="/gunicorn_conf.py" \
+      --config="./gunicorn_conf.py" \
       "dash_app.webviz_app:server"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,10 @@ RUN apt-get update \
          libc-dev-bin \
          libc6-dev \
     && pip install --no-cache-dir \
-         meinheld \
-         gunicorn \
-         flask \
          webviz-config \
          webviz-subsurface \ 
+         meinheld \
+         gunicorn \
     && PLOTLY_VERSION=$(find $DCC_DIR -maxdepth 1 -name 'plotly-*.min.js' | grep -oE "[0-9]+.[0-9]+.[0-9]+") \
     && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
     && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,41 @@
-FROM tiangolo/uwsgi-nginx-flask:python3.7
+FROM python:3.7-slim
 
-################################
-# Install the webviz ecosystem #
-################################
+LABEL maintainer="Equinor R&T"
 
-RUN pip install -U pip
-
-RUN pip install webviz-config webviz-subsurface
-
-# Change from full plotly bundle to one not depending on javascript eval.
-# See https://github.com/plotly/dash-core-components/issues/462 for details.
-
-ENV DCC_DIR='/usr/local/lib/python3.7/site-packages/dash_core_components'
-RUN PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o '[0-9]+.[0-9]+.[0-9]+'` \
-    && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
-    && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \
-    && sed -i "s/plotly-$PLOTLY_VERSION.min.js/plotly-cartesian-$PLOTLY_VERSION.min.js/g" $DCC_DIR/__init__.py
-
-##############################################
-# Prepare for adding the webviz instance app #
-##############################################
-
-ENV LISTEN_PORT=5000
 EXPOSE 5000
 
-COPY uwsgi.ini /
+ENV DCC_DIR="/usr/local/lib/python3.7/site-packages/dash_core_components"
 
-ENV UWSGI_INI /uwsgi.ini
-ENV STATIC_URL /dash_app/assets
+COPY . .
 
-WORKDIR /dash_app
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         wget \
+         gcc \
+         libgcc-6-dev \
+         gcc-6 \
+         libc-dev-bin \
+         libc6-dev \
+    && pip install --no-cache-dir \
+         meinheld \
+         gunicorn \
+         flask \
+         webviz-config \
+         webviz-subsurface \ 
+    && PLOTLY_VERSION=`ls $DCC_DIR/plotly-*.min.js | egrep -o "[0-9]+.[0-9]+.[0-9]+"` \
+    && wget https://github.com/plotly/plotly.js/raw/v$PLOTLY_VERSION/dist/plotly-cartesian.min.js \
+    && mv plotly-cartesian.min.js $DCC_DIR/plotly-cartesian-$PLOTLY_VERSION.min.js \
+    && sed -i "s/plotly-$PLOTLY_VERSION.min.js/plotly-cartesian-$PLOTLY_VERSION.min.js/g" $DCC_DIR/__init__.py \
+    && apt-get purge -y \
+         wget \
+         gcc \
+         libgcc-6-dev \
+         gcc-6 \
+         libc-dev-bin \
+         libc6-dev \
+    && apt-get autoremove -y \
+    && apt-get clean
+
+CMD gunicorn \
+      --config="/gunicorn_conf.py" \
+      "dash_app.webviz_app:server"

--- a/deploy_docker_image.sh
+++ b/deploy_docker_image.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-docker push webviz/base_image
+docker push webviz/base_image:latest

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -3,8 +3,10 @@ import multiprocessing
 # For documentation on gunicorn configuration settings, see
 # http://docs.gunicorn.org/en/stable/settings.html
 
-worker_class='egg:meinheld#gunicorn_worker'
+worker_class = 'egg:meinheld#gunicorn_worker'
 workers = 2 * multiprocessing.cpu_count()
+
+preload_app = True
 
 bind = '0.0.0.0:5000'
 keepalive = 120

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -1,0 +1,13 @@
+import multiprocessing
+
+# For documentation on gunicorn configuration settings, see
+# http://docs.gunicorn.org/en/stable/settings.html
+
+worker_class='egg:meinheld#gunicorn_worker'
+workers = 2 * multiprocessing.cpu_count()
+
+bind = '0.0.0.0:5000'
+keepalive = 120
+
+loglevel = 'info'
+errorlog = '-'

--- a/gunicorn_conf.py
+++ b/gunicorn_conf.py
@@ -10,4 +10,5 @@ bind = '0.0.0.0:5000'
 keepalive = 120
 
 loglevel = 'info'
+accesslog = '-'
 errorlog = '-'

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,7 +1,0 @@
-[uwsgi]
-module = dash_app.webviz_app
-callable = server
-uid = 1000
-master = true
-threads = 2
-processes = 4


### PR DESCRIPTION
Resolves #5 

- [X] Change from  `uwsgi-nginx` to `meinheld-gunicorn` stack (performance improvement).
- [X] Change from full Python image to slim base image (resulted in going from 1.81GB to ~200MB).
- [X] Added `USER` (called `appuser`) to dockerfile - making sure the webviz application process runs as non-root also within the container.

On merge, [this line in `webviz-config`](https://github.com/equinor/webviz-config/blob/a793fcfc3bb72f634ccb1514d9361b619d21a755/webviz_config/static/Dockerfile#L3) needs to be changed to
```
COPY --chown=appuser . dash_app
```
