### PR TITLE
Relax minor version in dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 webviz-config>=0.0.11
 webviz-subsurface>=0.0.7
-meinheld~=1.0.1
-gunicorn~=19.9.0
+meinheld~=1.0
+gunicorn~=19.9


### PR DESCRIPTION
Currently some requirements versions are given as `~= x.y.z`. This increases likelihood of version conflicts. Assuming dependencies are well behaving with respect to semantic versioning, it is better to state `~= x.y` in order to reduce risk of verson conflict. 

See [PEP 440](https://www.python.org/dev/peps/pep-0440/#compatible-release) for more information on compatible version specifiers.