### PR TITLE
Fix example image build

### DIFF
--- a/build_docker_base_image.sh
+++ b/build_docker_base_image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 PIP_PACKAGES=$(echo $(<./requirements.txt) | tr "\n" " ")
 
 docker build -t webviz/base_image . --build-arg PIP_PACKAGES="$PIP_PACKAGES"

--- a/build_docker_example_image.sh
+++ b/build_docker_example_image.sh
@@ -14,5 +14,5 @@ webviz certificate
 webviz build webviz-config/examples/basic_example.yaml --portable ./example_app
 
 pushd example_app
-docker build -t webviz/example_image
+docker build -t webviz/example_image .
 popd

--- a/build_docker_example_image.sh
+++ b/build_docker_example_image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 WEBVIZ_CONFIG_VERSION=$(python -c "import webviz_config; print(webviz_config.__version__)")
 
 git clone https://github.com/equinor/webviz-config.git

--- a/build_docker_example_image.sh
+++ b/build_docker_example_image.sh
@@ -8,12 +8,11 @@ git clone https://github.com/equinor/webviz-config.git
 
 pushd webviz-config
 git checkout $WEBVIZ_CONFIG_VERSION
+popd
 
 webviz certificate
 webviz build webviz-config/examples/basic_example.yaml --portable ./example_app
 
 pushd example_app
 docker build -t webviz/example_image
-popd
-
 popd

--- a/deploy_docker_images.sh
+++ b/deploy_docker_images.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 docker push webviz/base_image:latest


### PR DESCRIPTION
Add `set -e` to bash scripts such that they fail/stop immediately if one line fails.
Also, move corresponding `popd` of the `git checkout` command to the line directly after.